### PR TITLE
Fix nested f-string syntax error in confidence and accuracy extraction logic

### DIFF
--- a/samples/python/modules/samples/evaluation/comparison.py
+++ b/samples/python/modules/samples/evaluation/comparison.py
@@ -33,8 +33,8 @@ def get_extraction_comparison(expected: dict, actual: dict, confidence: dict, ac
             "Field": key,
             "Expected": expected_flat.get(key),
             "Extracted": extracted_flat.get(key),
-            "Confidence": f"{confidence_flat.get(f"{key}_confidence", 0.0) * 100:.2f}%",
-            "Accuracy": f"{'Match' if accuracy_flat.get(f"{key}", 0.0) == 1.0 else 'Mismatch'}"
+            "Confidence": f"{confidence_flat.get(f'{key}_confidence', 0.0) * 100:.2f}%",
+            "Accuracy": f"{'Match' if accuracy_flat.get(f'{key}', 0.0) == 1.0 else 'Mismatch'}"
         })
     df = pd.DataFrame(rows)
 


### PR DESCRIPTION
## Purpose

This PR fixes a syntax error in the logic that formats the Confidence and Accuracy fields when building the rows list. The error was caused by an invalid nested f-string using double quotes inside another f-string. This fix replaces the inner quotes with single quotes and simplifies the conditional formatting logic to ensure proper execution.

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Validation Steps Performed

Ran the script to ensure the updated formatting executes without syntax errors.

Verified that the output fields for Confidence and Accuracy display correctly across sample inputs.
